### PR TITLE
fuzztest travis fix

### DIFF
--- a/make/mt-config/mt-config.mk
+++ b/make/mt-config/mt-config.mk
@@ -61,7 +61,7 @@ endif
 
 # Settings that will work only on linux and only against clang-4.0 and greater
 ifneq (,$(findstring fuzz_test,$(CONFIG)))
-    IOTC_CONFIG_FLAGS += -fsanitize=address -fomit-frame-pointer -fsanitize-coverage=trace-8bit-counters -g
+    IOTC_CONFIG_FLAGS += -fsanitize=address -fomit-frame-pointer -fsanitize-coverage=inline-8bit-counters -g
 endif
 
 IOTC_COMMON_COMPILER_FLAGS += -Wall -Werror


### PR DESCRIPTION
The flag `-fsanitize-coverage=trace-pc-guard` got deprecated in libfuzzer. Replacement of it is `-fsanitize-coverage=inline-8bit-counters`.
svc logs from repo `https://llvm.org/svn/llvm-project/compiler-rt/trunk/lib/fuzzer/`:
```
r352566 | kcc | 2019-01-30 00:40:05 +0100 (Wed, 30 Jan 2019) | 1 line         
[libFuzzer] remove deprecated support for -fsanitize-coverage=trace-pc[-guard]
------------------------------------------------------------------------      
r352564 | kcc | 2019-01-30 00:37:20 +0100 (Wed, 30 Jan 2019) | 1 line         
[libFuzzer] remove deprecated support for -fsanitize-coverage=trace-pc[-guard]
------------------------------------------------------------------------      
r311798 | kcc | 2017-08-25 22:20:46 +0200 (Fri, 25 Aug 2017) | 1 line                                                   
[libFuzzer] prepare tests for switching from -fsanitize-coverage=trace-pc-guard to -fsanitize-coverage=inline-8bit-counters
```