### PR TITLE
A workaround in FreeRTOS BSP MEM to handle the inability to alloc zero

### DIFF
--- a/src/bsp/platform/freertos-posix/iotc_bsp_mem_freertos.c
+++ b/src/bsp/platform/freertos-posix/iotc_bsp_mem_freertos.c
@@ -22,6 +22,12 @@
 #include <portable.h>
 
 void* iotc_bsp_mem_alloc(size_t byte_count) {
+  // workaround: FreeRTOS's pvPortMalloc crashes if 0 size
+  // block is tried to be allocated.
+  if (0 == byte_count) {
+    byte_count = 1;
+  }
+
   void* ptr = (void*)pvPortMalloc(byte_count);
 
   if (NULL == ptr) {


### PR DESCRIPTION
Bug:
In case zero length string is passed as username in the `iotc_connect` function the FreeFRTOS example hangs/crashes. 

Description:
During the connection process the SDK copies username string (and all others) into internal data descriptor. An strlen(str) sized memory is allocated and if the string happens to be zero length the BSP MEM malloc is called with 0 bytes. The Zephyr and POSIX version handles this situation, the FreeRTOS hangs/crashes.

Solution, workaround:
Avoiding allocating 0 sized blocks in FreeRTOS BSP MEM by forcing allocation of a 1 byte size block.
Better solution would be to never try to alloc zero sized block but this latter is a larger effort affecting the whole SDK.

QA:
Manual execution of the FreeRTOS example. Result is a successful connection to the MQTT Bridge.