### PR TITLE
fix: in tools/create_buffer.py, output file must be open in text mode

### DIFF
--- a/tools/create_buffer.py
+++ b/tools/create_buffer.py
@@ -138,7 +138,7 @@ def write_to_file( file_name, s ):
 
     print("writing to: %s" % file_name)
 
-    with open( file_name, "wb" ) as f:
+    with open( file_name, "w" ) as f:
         f.write( s )
 
 if __name__ == '__main__':


### PR DESCRIPTION
Bug introduced by the Python3 migration. Output file was opened as binary mode, even though text is written.