### PR TITLE
Deletion of bsp/platform/posix/iotc_bsp_hton.h file.

### DIFF
--- a/src/bsp/platform/posix/iotc_bsp_hton.h
+++ b/src/bsp/platform/posix/iotc_bsp_hton.h
@@ -1,1 +1,0 @@
-#include <arpa/inet.h>


### PR DESCRIPTION
The functionality leaning on hton has been long removed.