### PR TITLE
CONTRIBUTING.md style guide link update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,11 @@ accept your pull requests.
 1. The repo owner will respond to your issue promptly.
 1. If your proposed change is accepted, and you haven't already done so, sign a
    Contributor License Agreement (see details above).
-1. Fork the desired repo, develop and test your code changes.
+1. Fork the desired repo, develop and test your code changes based off of the `development` branch.
 1. Ensure that your code adheres to the existing style in the sample to which
-   you are contributing. Refer to the
+   you are contributing.
+1. If your code requires a tutorial, readme, or other documentation, please refer to the
    [Google Cloud Platform Community Tutorial Style Guide](https://cloud.google.com/community/tutorials/styleguide)
    for the recommended coding standards for this organization.
 1. Ensure that your code has an appropriate set of unit tests which all pass.
-1. Submit a pull request.
-
+1. Submit a pull request PRs against the `development` branch. The master branch is for official releases only.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,6 @@ accept your pull requests.
 1. Ensure that your code adheres to the existing style in the sample to which
    you are contributing.
 1. If your code requires a tutorial, readme, or other documentation, please refer to the
-   [Google Cloud Platform Community Tutorial Style Guide](https://cloud.google.com/community/tutorials/styleguide)
-   for the recommended coding standards for this organization.
+   [Google Cloud Platform Community Tutorial Style Guide](https://cloud.google.com/community/tutorials/styleguide) for the recommended coding standards for this organization.
 1. Ensure that your code has an appropriate set of unit tests which all pass.
-1. Submit a pull request PRs against the `development` branch. The master branch is for official releases only.
+1. Submit a pull request against the `development` branch. The master branch is for official releases only.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ accept your pull requests.
 1. Fork the desired repo, develop and test your code changes.
 1. Ensure that your code adheres to the existing style in the sample to which
    you are contributing. Refer to the
-   [Google Cloud Platform Samples Style Guide](https://github.com/GoogleCloudPlatform/Template/wiki/style.html)
+   [Google Cloud Platform Community Tutorial Style Guide](https://cloud.google.com/community/tutorials/styleguide)
    for the recommended coding standards for this organization.
 1. Ensure that your code has an appropriate set of unit tests which all pass.
 1. Submit a pull request.


### PR DESCRIPTION
The old link points to an archived github page and is no longer accessible to the public.