### PR TITLE
Fix formatting in example README files

### DIFF
--- a/examples/freertos_linux/Linux_gcc_gcp_iot/README.md
+++ b/examples/freertos_linux/Linux_gcc_gcp_iot/README.md
@@ -8,20 +8,20 @@ Follow the steps below to connect the FreeRTOS application to the MQTT bridge.
 
 Before you begin, generate a [public/private key pair](https://cloud.google.com/iot/docs/how-tos/credentials/keys), store the private key in the `examples/freertos_linux/Linux_gcc_gcp_iot` directory, and name the key `ec_private.pem`. 
 
-1. Run `make PRESET=FREERTOS_POSIX_REL` in the root directory of the repository. This command downloads of the [FreeRTOS kernel](https://www.freertos.org/index.html), downloads the [FreeRTOS Linux simulator](https://www.freertos.org/FreeRTOS-simulator-for-Linux.html), and ports the Device SDK to the FreeRTOS application.
+1. Run `make PRESET=FREERTOS_POSIX_REL` in the root directory of the repository. This command downloads the [FreeRTOS kernel](https://www.freertos.org/index.html) and the [FreeRTOS Linux simulator](https://www.freertos.org/FreeRTOS-simulator-for-Linux.html), and ports the Device SDK to the FreeRTOS application.
 
 2. From the root directory, generate the `Linux_gcc_gcp_iot` application for Linux.
 
-```
-cd examples/freertos_linux/Linux_gcc_gcp_iot \
-make
-```
+   ```
+   cd examples/freertos_linux/Linux_gcc_gcp_iot
+   make
+   ```
 
 3. Run the following command to connect to Cloud IoT Core and issue a `PUBLISH` message every five seconds.
 
-<pre>
-./Linux_gcc_gcp_iot -p <i><b>PROJECT_ID</b></i> -d projects/<i><b>PROJECT_ID</b></i>/locations/<i><b>REGION</b></i>/registries/<i><b>REGISTRY_ID</b></i>/devices/<i><b>DEVICE_ID</b></i> -t /devices/<i><b>DEVICE_ID</b></i>/state
-</pre>
+   <pre>
+   ./Linux_gcc_gcp_iot -p <i><b>PROJECT_ID</b></i> -d projects/<i><b>PROJECT_ID</b></i>/locations/<i><b>REGION</b></i>/registries/<i><b>REGISTRY_ID</b></i>/devices/<i><b>DEVICE_ID</b></i> -t /devices/<i><b>DEVICE_ID</b></i>/state
+   </pre>
 
 ## Troubleshooting
 

--- a/examples/iot_core_mqtt_client/README.md
+++ b/examples/iot_core_mqtt_client/README.md
@@ -10,15 +10,15 @@ Before you begin, generate a [public/private key pair](https://cloud.google.com/
 
 2. From the root directory, generate the native example application.
 
-```
-cd examples/iot_core_mqtt_client \
-make
-```
+   ```
+   cd examples/iot_core_mqtt_client
+   make
+   ```
 
-3. Run the following commands, substituting in your device and project information.
+3. Run the following commands, substituting in your device and project information:
 
-<pre>
-make \
-cd bin \
-./iot_core_mqtt_client -p <i><b>PROJECT_ID</b></i> -d projects/<i><b>PROJECT_ID</b></i>/locations/<i><b>REGION</b></i>/registries/<i><b>REGISTRY_ID</b></i>/devices/<i><b>DEVICE_ID</b></i> -t /devices/<i><b>DEVICE_ID</b></i>/state
-</pre>
+   <pre>
+   make
+   cd bin
+   ./iot_core_mqtt_client -p <i><b>PROJECT_ID</b></i> -d projects/<i><b>PROJECT_ID</b></i>/locations/<i><b>REGION</b></i>/registries/<i><b>REGISTRY_ID</b></i>/devices/<i><b>DEVICE_ID</b></i> -t /devices/<i><b>DEVICE_ID</b></i>/state
+   </pre>

--- a/examples/zephyr_native_posix/README.md
+++ b/examples/zephyr_native_posix/README.md
@@ -1,6 +1,6 @@
 # Zephyr RTOS example
 
-This example uses the Google Cloud IoT Device SDK for Embedded C to connect a Zephyr native_posix board application to the [Google Cloud IoT Core MQTT bridge](https://cloud.google.com/iot/docs/how-tos/mqtt-bridge#iot-core-mqtt-auth-run-cpp).
+This example uses the Google Cloud IoT Device SDK for Embedded C to connect a Zephyr `native_posix` board application to the [Google Cloud IoT Core MQTT bridge](https://cloud.google.com/iot/docs/how-tos/mqtt-bridge#iot-core-mqtt-auth-run-cpp).
 
 ## Getting started
 Follow the steps below to connect the Zephyr application to the MQTT bridge.
@@ -9,29 +9,29 @@ Before you begin, generate a [public/private key pair](https://cloud.google.com/
 
 1. Run `make PRESET=ZEPHYR` in the root directory of the repository. This command includes `git clone` of the Zephyr repository, sets Zephyr required environment variables, and auto-generates `.h` files that the Zephyr BSP requries.
 
-2. From the root directory, generate the Zephyr native_posix board application.
+2. From the root directory, generate the Zephyr `native_posix` board application:
 
-```
-cd examples/zephyr_native_posix/build \
-make
-```
+   ```
+   cd examples/zephyr_native_posix/build
+   make
+   ```
 
 3. Run the following command to connect to Cloud IoT Core and issue a `PUBLISH` message every five seconds.
 
-<pre>
-zephyr/zephyr.exe -testargs -p <i><b>PROJECT_ID</b></i> -d projects/<i><b>PROJECT_ID</b></i>/locations/<i><b>REGION</b></i>/registries/<i><b>REGISTRY_ID</b></i>/devices/<i><b>DEVICE_ID</b></i> -t /devices/<i><b>DEVICE_ID</b></i>/state
-</pre>
+   <pre>
+   zephyr/zephyr.exe -testargs -p <i><b>PROJECT_ID</b></i> -d projects/<i><b>PROJECT_ID</b></i>/locations/<i><b>REGION</b></i>/registries/<i><b>REGISTRY_ID</b></i>/devices/<i><b>DEVICE_ID</b></i> -t /devices/<i><b>DEVICE_ID</b></i>/state
+   </pre>
 
 ## Troubleshooting
 
-### Setting up internet access on the native_posix board
-By default, the Zephyr application claims IP 192.0.2.1 and is in the same subnet with the `zeth` virtual network adapter at IP 192.0.2.2. This subnet must be connected to the internet. 
+### Setting up internet access on the `native_posix` board
+By default, the Zephyr application claims IP 192.0.2.1 and is in the same subnet with the `zeth` virtual network adapter at IP 192.0.2.2. This subnet must be connected to the internet.
 
 To ensure internet connectivity, run the [socket HTTP GET example](https://docs.zephyrproject.org/latest/samples/net/sockets/http_get/README.html).
 
 Read the following references to start the `zeth` virtual network adapter and connect the subnet to internet see the Zephyr instructions.
-- [Networking with native_posix board](https://docs.zephyrproject.org/latest/guides/networking/native_posix_setup.html)
-- [Setting up Zephyr and NAT and masquerading on host to access internet](https://docs.zephyrproject.org/latest/guides/networking/qemu_setup.html#setting-up-zephyr-and-nat-masquerading-on-host-to-access-internet) 
+- [Networking with `native_posix` board](https://docs.zephyrproject.org/latest/guides/networking/native_posix_setup.html)
+- [Setting up Zephyr and NAT and masquerading on host to access internet](https://docs.zephyrproject.org/latest/guides/networking/qemu_setup.html#setting-up-zephyr-and-nat-masquerading-on-host-to-access-internet)
 
 ### Setting up the Zephyr development system
 
@@ -39,4 +39,4 @@ Another way to set environment variables is by permanently set up the Zephyr env
 
 ### Validating Cloud IoT Core credentials
 
-Build the [MQTT client example](https://github.com/GoogleCloudPlatform/iot-device-sdk-embedded-c/tree/docs_updates/examples/iot_core_mqtt_client) to validate your Cloud IoT Core credentials.
+Build the [MQTT client example](../iot_core_mqtt_client) to validate your Cloud IoT Core credentials.

--- a/res/trusted_RootCA_certs/README.md
+++ b/res/trusted_RootCA_certs/README.md
@@ -1,3 +1,3 @@
-roots.pem is the concatenation of:
- - GTS LTSR (https://pki.goog/gtsltsr/gtsltsr.crt), as primary.
- - GS Root R4 (https://pki.goog/gsr4/GSR4.crt), as backup.
+[`roots.pem`](roots.pem) is the concatenation of:
+ - [GTS LTSR](https://pki.goog/gtsltsr/gtsltsr.crt), as primary.
+ - [GS Root R4](https://pki.goog/gsr4/GSR4.crt), as backup.


### PR DESCRIPTION
* use code formatting as needed
* add/fix links via Markdown
* use indentation to put command examples under the bullet they
  correspond to
* remove backslashes which separate multiple commands as they need to be
  run as separate commands, not as continuations of a single command