### PR TITLE
Makefile: clean: Also clean TLS library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ clean:
 	$(RM) -rf \
 		$(IOTC_BINDIR) \
 		$(IOTC_OBJDIR)
+	$(MAKE) -C $(IOTC_TLS_LIB_SRC_DIR) clean
 
 clean_all: clean
 	$(RM) -rf \


### PR DESCRIPTION
This is needed to build SDK for different targets. E.g., we had issues
switching between POSIX and Zephyr builds, as mbedTLS wasn't rebuilt
for the right target, and old library was picked up for linking, causing
errors.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>