### PR TITLE
zephyr_bsp/iotc_bsp_io_fs_zephyr.c: Use standard <string.h> header.

### DIFF
--- a/src/bsp/platform/zephyr/iotc_bsp_io_fs_zephyr.c
+++ b/src/bsp/platform/zephyr/iotc_bsp_io_fs_zephyr.c
@@ -22,7 +22,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <iotc_fs_bsp_to_iotc_mapping.h>
-#include <memory.h>
+#include <string.h>
 #include <stdio.h>
 #include <sys/stat.h>
 #include <unistd.h>


### PR DESCRIPTION
There's no <memory.h> in ANSI C or POSIX.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>