### PR TITLE
[bugfix] Zephyr native_posix debug output segfault when printing int64_t

### DIFF
--- a/src/libiotc/iotc_debug.h
+++ b/src/libiotc/iotc_debug.h
@@ -50,20 +50,20 @@ void iotc_debug_data_logger_impl(const char* msg,
 
 #define iotc_debug_logger(msg)                                               \
   __iotc_printf(                                                             \
-      "[%"PRId64"][%s:%d (%s)] %s\n", iotc_bsp_time_getcurrenttime_milliseconds(), \
+      "[%lld][%s:%d (%s)] %s\n", iotc_bsp_time_getcurrenttime_milliseconds(), \
       iotc_debug_dont_print_the_path(__FILE__), __LINE__, __func__, msg)
 #define iotc_debug_format(fmt, ...)                                           \
-  __iotc_printf("[%"PRId64"][%s:%d (%s)] " fmt "\n",                                \
+  __iotc_printf("[%lld][%s:%d (%s)] " fmt "\n",                                \
                 iotc_bsp_time_getcurrenttime_milliseconds(),                  \
                 iotc_debug_dont_print_the_path(__FILE__), __LINE__, __func__, \
                 __VA_ARGS__)
 #define iotc_debug_printf(...) __iotc_printf(__VA_ARGS__)
 #define iotc_debug_function_entered()                        \
-  __iotc_printf("[%"PRId64"][%s:%d (%s)] -> entered\n",            \
+  __iotc_printf("[%lld][%s:%d (%s)] -> entered\n",            \
                 iotc_bsp_time_getcurrenttime_milliseconds(), \
                 iotc_debug_dont_print_the_path(__FILE__), __LINE__, __func__)
 #define iotc_debug_data_logger(msg, dsc)                                       \
-  __iotc_printf("[%"PRId64"][%s:%d (%s)] #\n",                                       \
+  __iotc_printf("[%lld][%s:%d (%s)] #\n",                                       \
                 iotc_bsp_time_getcurrenttime_milliseconds(),                   \
                 iotc_debug_dont_print_the_path(__FILE__), __LINE__, __func__); \
   iotc_debug_data_logger_impl(msg, dsc)
@@ -78,7 +78,7 @@ void iotc_debug_data_logger_impl(const char* msg,
 #define IOTC_LAYER_FUNCTION_PRINT_FUNCTION_DIGEST()
 #define IOTC_LAYER_FUNCTION_PRINT_FUNCTION_DIGEST_OFF()      \
   __iotc_printf(                                             \
-      "[%"PRId64"] %-50s, layerchainid = %p, in_out_state = %d, "  \
+      "[%lld] %-50s, layerchainid = %p, in_out_state = %d, "  \
       "layer_type_id = "                                     \
       "%d, data = %p\n",                                     \
       iotc_bsp_time_getcurrenttime_milliseconds(), __func__, \

--- a/src/libiotc/iotc_debug.h
+++ b/src/libiotc/iotc_debug.h
@@ -50,20 +50,20 @@ void iotc_debug_data_logger_impl(const char* msg,
 
 #define iotc_debug_logger(msg)                                               \
   __iotc_printf(                                                             \
-      "[%ld][%s:%d (%s)] %s\n", iotc_bsp_time_getcurrenttime_milliseconds(), \
+      "[%"PRId64"][%s:%d (%s)] %s\n", iotc_bsp_time_getcurrenttime_milliseconds(), \
       iotc_debug_dont_print_the_path(__FILE__), __LINE__, __func__, msg)
 #define iotc_debug_format(fmt, ...)                                           \
-  __iotc_printf("[%ld][%s:%d (%s)] " fmt "\n",                                \
+  __iotc_printf("[%"PRId64"][%s:%d (%s)] " fmt "\n",                                \
                 iotc_bsp_time_getcurrenttime_milliseconds(),                  \
                 iotc_debug_dont_print_the_path(__FILE__), __LINE__, __func__, \
                 __VA_ARGS__)
 #define iotc_debug_printf(...) __iotc_printf(__VA_ARGS__)
 #define iotc_debug_function_entered()                        \
-  __iotc_printf("[%ld][%s:%d (%s)] -> entered\n",            \
+  __iotc_printf("[%"PRId64"][%s:%d (%s)] -> entered\n",            \
                 iotc_bsp_time_getcurrenttime_milliseconds(), \
                 iotc_debug_dont_print_the_path(__FILE__), __LINE__, __func__)
 #define iotc_debug_data_logger(msg, dsc)                                       \
-  __iotc_printf("[%ld][%s:%d (%s)] #\n",                                       \
+  __iotc_printf("[%"PRId64"][%s:%d (%s)] #\n",                                       \
                 iotc_bsp_time_getcurrenttime_milliseconds(),                   \
                 iotc_debug_dont_print_the_path(__FILE__), __LINE__, __func__); \
   iotc_debug_data_logger_impl(msg, dsc)
@@ -78,7 +78,7 @@ void iotc_debug_data_logger_impl(const char* msg,
 #define IOTC_LAYER_FUNCTION_PRINT_FUNCTION_DIGEST()
 #define IOTC_LAYER_FUNCTION_PRINT_FUNCTION_DIGEST_OFF()      \
   __iotc_printf(                                             \
-      "[%ld] %-50s, layerchainid = %p, in_out_state = %d, "  \
+      "[%"PRId64"] %-50s, layerchainid = %p, in_out_state = %d, "  \
       "layer_type_id = "                                     \
       "%d, data = %p\n",                                     \
       iotc_bsp_time_getcurrenttime_milliseconds(), __func__, \

--- a/src/libiotc/iotc_jwt.c
+++ b/src/libiotc/iotc_jwt.c
@@ -50,7 +50,7 @@ static iotc_bsp_crypto_state_t _iotc_create_iotcore_jwt_b64h_b64p(
 
   char payload[IOTC_JWT_PAYLOAD_BUF_SIZE] = {0};
   snprintf(payload, IOTC_JWT_PAYLOAD_BUF_SIZE,
-           "{\"iat\":%"PRId64",\"exp\":%lld,\"aud\":\"%s\"}", current_time_in_sec,
+           "{\"iat\":%lld,\"exp\":%lld,\"aud\":\"%s\"}", current_time_in_sec,
            current_time_in_sec + expiration_period_sec, project_id);
 
   // base64 encode, header

--- a/src/libiotc/iotc_jwt.c
+++ b/src/libiotc/iotc_jwt.c
@@ -50,7 +50,7 @@ static iotc_bsp_crypto_state_t _iotc_create_iotcore_jwt_b64h_b64p(
 
   char payload[IOTC_JWT_PAYLOAD_BUF_SIZE] = {0};
   snprintf(payload, IOTC_JWT_PAYLOAD_BUF_SIZE,
-           "{\"iat\":%lld,\"exp\":%lld,\"aud\":\"%s\"}", current_time_in_sec,
+           "{\"iat\":%"PRId64",\"exp\":%lld,\"aud\":\"%s\"}", current_time_in_sec,
            current_time_in_sec + expiration_period_sec, project_id);
 
   // base64 encode, header


### PR DESCRIPTION
Bug:
The change of time representation type long --> int64_t in #56 made the Zephyr example native_posix builds crash when printing a debug output. Namely the timestamp at the beginning of a debug line.

Fix:
Changing the %ld to %lld.