### PR TITLE
Chaning FreeRTOS download url since the old one's TLS cert has expired

### DIFF
--- a/make/mt-os/mt-freertos-linux.mk
+++ b/make/mt-os/mt-freertos-linux.mk
@@ -44,7 +44,7 @@ IOTC_COMMON_COMPILER_FLAGS += -Wno-format
 #################################################################
 # Download FreeRTOS kernel and FreeRTOS Plus Linux Simulator ####
 #################################################################
-IOTC_FREERTOS_KERNEL_URL=https://kent.dl.sourceforge.net/project/freertos/FreeRTOS/V10.1.1/FreeRTOSv10.1.1.zip
+IOTC_FREERTOS_KERNEL_URL=https://sourceforge.net/projects/freertos/files/FreeRTOS/V10.1.1/FreeRTOSv10.1.1.zip/download
 IOTC_FREERTOS_KERNEL_ZIP_PATH=$(LIBIOTC)/third_party/FreeRTOSv10.1.1.zip
 IOTC_FREERTOS_KERNEL_DIR_PATH=$(basename $(IOTC_FREERTOS_KERNEL_ZIP_PATH))
 IOTC_FREERTOS_KERNEL_README_PATH=$(IOTC_FREERTOS_KERNEL_DIR_PATH)/readme.txt
@@ -72,7 +72,7 @@ $(IOTC_FREERTOS_KERNEL_README_PATH): $(IOTC_FREERTOS_KERNEL_ZIP_PATH)
 # Download FreeRTOS kernel ######################################
 #################################################################
 $(IOTC_FREERTOS_KERNEL_ZIP_PATH):
-	@echo "IOTC FreeRTOS Linux build: downloading FreeRTOS Kernel to file $@"
+	@echo "IOTC FreeRTOS Linux build: downloading FreeRTOS Kernel to file $@ from $(IOTC_FREERTOS_KERNEL_URL)"
 	@-mkdir -p $(dir $@)
 	@curl -L -o $@ $(IOTC_FREERTOS_KERNEL_URL)
 


### PR DESCRIPTION
[BUG] Travis FreeRTOS builds failed because the server's TLS cert was expired (https://kent.dl.sourceforge.net/project/freertos/FreeRTOS/V10.1.1/FreeRTOSv10.1.1.zip), so curl denied downloading the FreeRTOS.zip.
"Expired: 2019. July 21., Sunday 1:27:39 Central European Summer Time"

[FIX] Other download server was chosen: https://sourceforge.net/projects/freertos/files/FreeRTOS/V10.1.1/FreeRTOSv10.1.1.zip/download

[TEST] Travis builds pass for all targets.